### PR TITLE
✨ Feat: Button(s) to insert/move prerequisite modules to timeline to resolve dependencies

### DIFF
--- a/src/firebaseconfig/index.ts
+++ b/src/firebaseconfig/index.ts
@@ -36,7 +36,8 @@ export const modulesFirebase$ = fromEvent((firebase as any).database().ref('/mod
     return rows.map(row => row.reduce((acc, n, i) => ({...acc, [headers[i].toLowerCase().split(' ')[1]]: n}), {}))
       .map((row): ContentModule => ({
         ...row,
-        ins: row.ins.split(','),
+        // Prevent `ins` from including empty string elements.
+        ins: row.ins.split(',').filter( i => i.length > 0),
         challenges: row.challenges.split(' '),
         extras: row.extras.split(' '),
       }));

--- a/src/scenes/home/alert-list/alert-list-item/alert-list-item.component.tsx
+++ b/src/scenes/home/alert-list/alert-list-item/alert-list-item.component.tsx
@@ -1,36 +1,50 @@
 import * as React from 'react';
 
 import { Alert } from '../alert-list.content';
+import { INSERT_MODULE_IN_TIMELINE } from '../../../../state/actions/insertModuleInTimeline';
 
 interface Props {
-  alert: Alert;
-
-  dispatch?: any;
+    alert: Alert;
+    dispatch?: any;
 }
 
-const AlertListItem: React.SFC<Props> = ({ alert }: Props) => {
-
-  return (
-    <div key={alert.id} className="flex flex-column items-center bg-near-white justify-between pa2 ma2">
-        <h3 className="ma1">{`Module "${alert.module.name}" has unmet prequisites:`}</h3>
-        <div>
-            {
-                alert.missing.map(module => (
-                    <div key={`missing-${module.id}`}>
-                        {`⚠️ Prerequisite "${module.name}" missing from lesson plan.`}
-                    </div>
-                ))
-            }
-            {
-                alert.following.map(module => (
-                    <div key={`following-${module.id}`}>
-                        {`⏰ Prerequisite "${module.name}" should be taught before this module.`}
-                    </div>
-                ))
-            }
+const AlertListItem: React.SFC<Props> = ({ alert, dispatch }: Props) => {
+    const addPrerequisiteModule = (id, targetPosition) => dispatch(
+        INSERT_MODULE_IN_TIMELINE.createAction({ id, targetPosition })
+    );
+    return (
+        <div key={alert.id} className="flex flex-column items-center bg-near-white justify-between pa2 ma2">
+            <h3 className="ma1">{`Module "${alert.module.name}" has unmet prequisites:`}</h3>
+            <div>
+                {
+                    alert.missing.map(module => (
+                        <div key={`missing-${module.id}`}>
+                            {`⚠️ Prerequisite "${module.name}" missing from lesson plan.`}
+                            <span
+                                className="ml2 link underline-hover blue"
+                                onClick={() => addPrerequisiteModule(module.id, alert.targetPosition)}
+                            >
+                                Add Module
+                            </span>
+                        </div>
+                    ))
+                }
+                {
+                    alert.following.map(module => (
+                        <div key={`following-${module.id}`}>
+                            {`⏰ Prerequisite "${module.name}" should be taught before this module.`}
+                            <span
+                                className="ml2 link underline-hover blue"
+                                onClick={() => addPrerequisiteModule(module.id, alert.targetPosition)}
+                            >
+                                Move Module
+                            </span>                            
+                        </div>
+                    ))
+                }
+            </div>
         </div>
-    </div>
-  );
+    );
 };
 
 export {

--- a/src/scenes/home/alert-list/alert-list.component.tsx
+++ b/src/scenes/home/alert-list/alert-list.component.tsx
@@ -32,6 +32,7 @@ const AlertList: React.SFC<Props> = ({
                     <AlertListItem
                         key={`ali-${alert.id}`}
                         alert={alert}
+                        dispatch={dispatch}
                     />
                 ))
             }
@@ -61,6 +62,7 @@ const selectAlerts = createSelector(
                 const followingPrequisiteModuleIds = difference(unmetPrequisites, missingPrequisiteModuleIds);
                 const newAlert = {
                     id: module.id,
+                    targetPosition: index,
                     module: module,
                     following: modules.filter(followingModule =>
                         followingPrequisiteModuleIds.includes(followingModule.id)

--- a/src/scenes/home/alert-list/alert-list.content.ts
+++ b/src/scenes/home/alert-list/alert-list.content.ts
@@ -2,6 +2,7 @@ import { ContentModule } from '../../../constants';
 
 export interface Alert {
     id: string;
+    targetPosition: number;
     module: ContentModule;
     missing?: Array<ContentModule>;
     following?: Array<ContentModule>;

--- a/src/state/actions/index.ts
+++ b/src/state/actions/index.ts
@@ -1,12 +1,14 @@
 import { DRAG_MODULE } from './dragModule';
 import { DROP_MODULE } from './dropModule';
 import { GET_MODULES } from './getModules';
+import { INSERT_MODULE_IN_TIMELINE } from './insertModuleInTimeline';
 
 export enum TypeKeys {
     DRAG_MODULE = 'DRAG_MODULE',
     DROP_MODULE = 'DROP_MODULE',
     GET_MODULES = 'GET_MODULES',
     SET_CURRENT_MODULE = 'SET_CURRENT_MODULE',
+    INSERT_MODULE_IN_TIMELINE = 'INSERT_MODULE_IN_TIMELINE',
 }
 
 type ActionTypes = {
@@ -17,6 +19,7 @@ export type Payload = {
     payload: DRAG_MODULE.DragModulePayload
         | DROP_MODULE.DropModulePayload
         | GET_MODULES.GetModulePayload
+        | INSERT_MODULE_IN_TIMELINE.InsertModuleInTimelinePayload
 };
 
 export type Action = ActionTypes & Payload;

--- a/src/state/actions/insertModuleInTimeline.ts
+++ b/src/state/actions/insertModuleInTimeline.ts
@@ -1,0 +1,18 @@
+export const INSERT_MODULE_IN_TIMELINE_TOKEN = 'INSERT_MODULE_IN_TIMELINE';
+
+export namespace INSERT_MODULE_IN_TIMELINE {
+    export type InsertModuleInTimelinePayload = {
+        id: string;
+        targetPosition: number,
+    };
+
+    export type InsertModuleInTimelineAction = {
+        type: typeof INSERT_MODULE_IN_TIMELINE_TOKEN,
+        payload: InsertModuleInTimelinePayload
+    };
+
+    export const createAction = (payload: InsertModuleInTimelinePayload) => ({
+        type: INSERT_MODULE_IN_TIMELINE_TOKEN,
+        payload
+    });
+}


### PR DESCRIPTION
This PR resolves #28 - it allows a user creating a lesson plan to easily resolve dependency/prerequisite warnings (missing or out of sequence). Simple link buttons are provided with the warning message that can be actioned to immediately resolve the gap.

Screenshot:
![resolve-prereqs](https://user-images.githubusercontent.com/4238814/40363383-5b1ede68-5d9d-11e8-9f21-bd1ff93770ce.gif)
